### PR TITLE
fix: c++11 compilation error

### DIFF
--- a/src/shm_list.h
+++ b/src/shm_list.h
@@ -79,8 +79,8 @@ static inline void shm_list_delete(struct shmcache_list *list, int64_t obj_offse
 
     node = SHM_LIST_PTR(list, obj_offset);
     if (node->next == obj_offset) {
-        logError("file: "__FILE__", line: %d, "
-                "do NOT need remove from list, obj: %"PRId64,
+        logError("file: " __FILE__", line: %d, "
+                "do NOT need remove from list, obj: %" PRId64,
                 __LINE__, obj_offset);
         return;
     }

--- a/src/shmopt.h
+++ b/src/shmopt.h
@@ -63,7 +63,7 @@ static inline char *shmopt_get_value_segment(struct shmcache_context *context,
         }
         return context->segments.values.items[index].base;
     } else {
-        logError("file: "__FILE__", line: %d, "
+        logError("file: " __FILE__", line: %d, "
                 "invalid index: %d >= %d", __LINE__,
                 index, context->memory->vm_info.segment.count.current);
         return NULL;


### PR DESCRIPTION
Thanks for your library :D

When developing a Node.js Wrapper,  an error was thrown on compilation

```
unable to find string literal operator 'operator"" __FILE__'
```

http://stackoverflow.com/questions/30530881/facing-unable-to-find-string-literal-operator-error-when-compiling-ui-code-wit